### PR TITLE
Recursively search for mp3 files on input path

### DIFF
--- a/audiogrep.py
+++ b/audiogrep.py
@@ -212,6 +212,14 @@ if __name__ == '__main__':
     if not args.search and not args.transcribe:
         parser.error('Please transcribe files [--transcribe] or search [--search SEARCH] already transcribed files')
 
+    inputfiles = []
+    if args.recur:
+        for root, dirname, filenames in os.walk(str(args.inputfile[0])):
+            for filename in fnmatch.filter(filenames, '*mp3'):
+                inputfiles.append(os.path.join(root, filename))
+    else:
+        inputfiles = args.inputfile
+
     if args.transcribe:
         try:
             devnull = open(os.devnull)
@@ -221,22 +229,14 @@ if __name__ == '__main__':
                 print 'Error: Please install pocketsphinx to transcribe files.'
                 sys.exit()
 
-        inputfiles = []
-        if args.recur:
-            for root, dirname, filenames in os.walk(str(args.inputfile[0])):
-                for filename in fnmatch.filter(filenames, '*.mp3'):
-                    inputfiles.append(os.path.join(root, filename))
-        else:
-            inputfiles = args.inputfile
-
         files = convert_to_wav(inputfiles)
         transcribe(files)
 
     if args.search:
         if args.outputmode == 'franken':
-            segments = franken_sentence(args.search, args.inputfile)
+            segments = franken_sentence(args.search, inputfiles)
         else:
-            segments = search(args.search, args.inputfile, mode=args.outputmode, regex=args.regex)
+            segments = search(args.search, inputfiles, mode=args.outputmode, regex=args.regex)
 
         if len(segments) == 0:
             print 'No results for "' + args.search + '"'

--- a/audiogrep.py
+++ b/audiogrep.py
@@ -226,7 +226,6 @@ if __name__ == '__main__':
             for root, dirname, filenames in os.walk(str(args.inputfile[0])):
                 for filename in fnmatch.filter(filenames, '*.mp3'):
                     inputfiles.append(os.path.join(root, filename))
-                    print(inputfiles)
         else:
             inputfiles = args.inputfile
 

--- a/audiogrep.py
+++ b/audiogrep.py
@@ -13,6 +13,7 @@ import subprocess
 import argparse
 import re
 import random
+import fnmatch
 from pydub import AudioSegment
 
 
@@ -204,6 +205,7 @@ if __name__ == '__main__':
     parser.add_argument('--crossfade', '-c', dest='crossfade', type=int, default=0, help='Crossfade between clips')
     parser.add_argument('--demo', '-d', dest='demo', action='store_true', help='Just display the search results without actually making the file')
     parser.add_argument('--layer', '-l', dest='layer', action='store_true', help='Overlay the audio segments')
+    parser.add_argument('--recursive', '-r', dest='recur', action='store_true', help='recursively search directory for mp3')
 
     args = parser.parse_args()
 
@@ -218,7 +220,17 @@ if __name__ == '__main__':
             if e.errno == os.errno.ENOENT:
                 print 'Error: Please install pocketsphinx to transcribe files.'
                 sys.exit()
-        files = convert_to_wav(args.inputfile)
+
+        inputfiles = []
+        if args.recur:
+            for root, dirname, filenames in os.walk(str(args.inputfile[0])):
+                for filename in fnmatch.filter(filenames, '*.mp3'):
+                    inputfiles.append(os.path.join(root, filename))
+                    print(inputfiles)
+        else:
+            inputfiles = args.inputfile
+
+        files = convert_to_wav(inputfiles)
         transcribe(files)
 
     if args.search:


### PR DESCRIPTION
If a user wants to use audiogrep on all mp3 files which have a root path of `--input $ROOTDIR` then all the user has to do is to set the `-r` or `--recursive` flags.